### PR TITLE
Fix: 修正課程描述中「英語授課」判斷邏輯，避免只判斷結尾

### DIFF
--- a/utils/parse_info.py
+++ b/utils/parse_info.py
@@ -90,11 +90,11 @@ def parse_course_info(
         # check if the course is taught in English
         # Since some descriptions have multiple identical suffixes,
         # use while to check multiple times.
-        english = False
-        while description.endswith("※英語授課"):
-            english = True
-            description = description[:-6]
-        description = description.strip()
+
+        # Fix: "※英語授課" may appear in the middle of the description
+        english = "※英語授課" in description
+        description = description.replace("※英語授課", "").strip()
+
 
         info_url_el = d.select_one("td:nth-child(8) small a[href]")
         assert info_url_el, "info_url_el is None"


### PR DESCRIPTION
原程式僅判斷description結尾是否有"※英語授課"標記，然而選課系統**可能將其標記在任何區段**（大多為前方）。

- 移除原本僅使用 .endswith("※英語授課") 的判斷方式。
- 修正為檢查 description 中是否包含該標記，並使用 replace() 移除所有出現的標記。